### PR TITLE
Fix compute disks

### DIFF
--- a/tests/data/compute_instance_creation_logs_1.json
+++ b/tests/data/compute_instance_creation_logs_1.json
@@ -1,0 +1,193 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-23T19:35:57.750392Z",
+        "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/console-devicenames",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/disk2name",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+    "request": {
+      "scheduling": {
+        "onHostMaintenance": "MIGRATE",
+        "automaticRestart": true,
+        "preemptible": false
+      },
+      "serviceAccounts": [
+        {
+          "email": "714682308094-compute@developer.gserviceaccount.com",
+          "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/trace.append"
+          ]
+        }
+      ],
+      "reservationAffinity": {
+        "consumeReservationType": "ANY_ALLOCATION"
+      },
+      "shieldedInstanceConfig": {
+        "enableVtpm": true,
+        "enableSecureBoot": false,
+        "enableIntegrityMonitoring": true
+      },
+      "machineType": "projects/test-project/zones/us-central1-a/machineTypes/e2-medium",
+      "displayDevice": {
+        "enableDisplay": false
+      },
+      "confidentialInstanceConfig": {
+        "enableConfidentialCompute": false
+      },
+      "name": "console-devicenames",
+      "deletionProtection": false,
+      "disks": [
+        {
+          "autoDelete": true,
+          "type": "PERSISTENT",
+          "deviceName": "devicename",
+          "boot": true,
+          "mode": "READ_WRITE",
+          "initializeParams": {
+            "diskSizeGb": "10",
+            "sourceImage": "projects/debian-cloud/global/images/debian-10-buster-v20210420",
+            "diskType": "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced"
+          }
+        },
+        {
+          "autoDelete": false,
+          "mode": "READ_WRITE",
+          "initializeParams": {
+            "diskType": "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced",
+            "diskSizeGb": "500",
+            "description": "",
+            "diskName": "disk2name"
+          },
+          "deviceName": "disk2devicename",
+          "type": "PERSISTENT"
+        }
+      ],
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "networkInterfaces": [
+        {
+          "subnetwork": "projects/test-project/regions/us-central1/subnetworks/default",
+          "accessConfigs": [
+            {
+              "networkTier": "PREMIUM",
+              "name": "External NAT"
+            }
+          ]
+        }
+      ],
+      "description": "",
+      "canIpForward": false
+    },
+    "response": {
+      "@type": "type.googleapis.com/operation",
+      "name": "operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+      "user": "test.user@cleardata.com",
+      "progress": "0",
+      "status": "RUNNING",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+      "operationType": "insert",
+      "selfLinkWithId": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/2395682771775168370",
+      "id": "2395682771775168370",
+      "targetId": "1515444269730406258",
+      "targetLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/instances/console-devicenames",
+      "insertTime": "2021-04-23T12:35:57.567-07:00",
+      "zone": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a",
+      "startTime": "2021-04-23T12:35:57.570-07:00"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1-a"
+      ]
+    }
+  },
+  "insertId": "77sfxfe1ryso",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-central1-a",
+      "instance_id": "1515444269730406258",
+      "project_id": "test-project"
+    }
+  },
+  "timestamp": "2021-04-23T19:35:56.947852Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-23T19:35:58.649788422Z"
+}

--- a/tests/data/compute_instance_creation_logs_2.json
+++ b/tests/data/compute_instance_creation_logs_2.json
@@ -1,0 +1,36 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0,gzip(gfe),gzip(gfe)"
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.instances.insert",
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/console-devicenames",
+    "request": {
+      "@type": "type.googleapis.com/compute.instances.insert"
+    }
+  },
+  "insertId": "k9bodhd531s",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-central1-a",
+      "project_id": "test-project",
+      "instance_id": "1515444269730406258"
+    }
+  },
+  "timestamp": "2021-04-23T19:36:05.525118Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206556904-5c0a8e7a46b69-07d8da26-0d3c1532",
+    "producer": "compute.googleapis.com",
+    "last": true
+  },
+  "receiveTimestamp": "2021-04-23T19:36:06.110416993Z"
+}

--- a/tests/data/compute_instance_creation_logs_3.json
+++ b/tests/data/compute_instance_creation_logs_3.json
@@ -1,0 +1,172 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:88.0) Gecko/20100101 Firefox/88.0,gzip(gfe),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-23T19:36:17.686966Z",
+        "reason": "8uSywAYQGg5Db2xpc2V1bSBGbG93cw",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "beta.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-nochange",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/console-nochange",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/console-nochange",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/console-nochange",
+    "request": {
+      "description": "",
+      "deletionProtection": false,
+      "name": "console-nochange",
+      "scheduling": {
+        "automaticRestart": true,
+        "preemptible": false,
+        "onHostMaintenance": "MIGRATE"
+      },
+      "disks": [
+        {
+          "mode": "READ_WRITE",
+          "boot": true,
+          "initializeParams": {
+            "diskSizeGb": "10",
+            "diskType": "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced",
+            "sourceImage": "projects/debian-cloud/global/images/debian-10-buster-v20210420"
+          },
+          "autoDelete": true,
+          "deviceName": "console-nochange",
+          "type": "PERSISTENT"
+        }
+      ],
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/trace.append"
+          ],
+          "email": "714682308094-compute@developer.gserviceaccount.com"
+        }
+      ],
+      "reservationAffinity": {
+        "consumeReservationType": "ANY_ALLOCATION"
+      },
+      "shieldedInstanceConfig": {
+        "enableSecureBoot": false,
+        "enableVtpm": true,
+        "enableIntegrityMonitoring": true
+      },
+      "machineType": "projects/test-project/zones/us-central1-a/machineTypes/e2-medium",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "canIpForward": false,
+      "confidentialInstanceConfig": {
+        "enableConfidentialCompute": false
+      },
+      "displayDevice": {
+        "enableDisplay": false
+      },
+      "networkInterfaces": [
+        {
+          "subnetwork": "projects/test-project/regions/us-central1/subnetworks/default",
+          "accessConfigs": [
+            {
+              "networkTier": "PREMIUM",
+              "name": "External NAT"
+            }
+          ]
+        }
+      ]
+    },
+    "response": {
+      "operationType": "insert",
+      "progress": "0",
+      "status": "RUNNING",
+      "id": "7760612956209848158",
+      "targetLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/instances/console-nochange",
+      "name": "operation-1619206576834-5c0a8e8d4874b-37ab70b0-80662f0b",
+      "startTime": "2021-04-23T12:36:17.518-07:00",
+      "targetId": "7230167568687734622",
+      "zone": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a",
+      "selfLink": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/operation-1619206576834-5c0a8e8d4874b-37ab70b0-80662f0b",
+      "selfLinkWithId": "https://www.googleapis.com/compute/beta/projects/test-project/zones/us-central1-a/operations/7760612956209848158",
+      "user": "test.user@cleardata.com",
+      "@type": "type.googleapis.com/operation",
+      "insertTime": "2021-04-23T12:36:17.515-07:00"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1-a"
+      ]
+    }
+  },
+  "insertId": "mhibhfe1ycbg",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "project_id": "test-project",
+      "zone": "us-central1-a",
+      "instance_id": "7230167568687734622"
+    }
+  },
+  "timestamp": "2021-04-23T19:36:16.875922Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206576834-5c0a8e8d4874b-37ab70b0-80662f0b",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-23T19:36:18.213428055Z"
+}

--- a/tests/data/compute_instance_creation_logs_4.json
+++ b/tests/data/compute_instance_creation_logs_4.json
@@ -1,0 +1,153 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "test.user@cleardata.com"
+    },
+    "requestMetadata": {
+      "callerIp": "76.98.160.101",
+      "callerSuppliedUserAgent": "google-cloud-sdk gcloud/327.0.0 command/gcloud.compute.instances.create invocation-id/6e49e932e1a34fbd9db966d667014b9e environment/None environment-version/None interactive/True from-script/False python/3.7.8 term/xterm-256color (Macintosh; Intel Mac OS X 20.3.0),gzip(gfe)",
+      "requestAttributes": {
+        "time": "2021-04-23T19:40:10.894836Z",
+        "auth": {}
+      },
+      "destinationAttributes": {}
+    },
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "authorizationInfo": [
+      {
+        "permission": "compute.instances.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+          "type": "compute.instances"
+        }
+      },
+      {
+        "permission": "compute.disks.create",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/disks/gcloud-devicename-mismatch",
+          "type": "compute.disks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.use",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.subnetworks.useExternalIp",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/regions/us-central1/subnetworks/default",
+          "type": "compute.subnetworks"
+        }
+      },
+      {
+        "permission": "compute.instances.setServiceAccount",
+        "granted": true,
+        "resourceAttributes": {
+          "service": "compute",
+          "name": "projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+          "type": "compute.instances"
+        }
+      }
+    ],
+    "resourceName": "projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+    "request": {
+      "deletionProtection": false,
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write",
+            "https://www.googleapis.com/auth/monitoring.write",
+            "https://www.googleapis.com/auth/pubsub",
+            "https://www.googleapis.com/auth/service.management.readonly",
+            "https://www.googleapis.com/auth/servicecontrol",
+            "https://www.googleapis.com/auth/trace.append"
+          ],
+          "email": "default"
+        }
+      ],
+      "name": "gcloud-devicename-mismatch",
+      "canIpForward": false,
+      "scheduling": {
+        "automaticRestart": true
+      },
+      "machineType": "https://compute.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/machineTypes/n1-standard-1",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "networkInterfaces": [
+        {
+          "accessConfigs": [
+            {
+              "name": "external-nat",
+              "type": "ONE_TO_ONE_NAT"
+            }
+          ],
+          "network": "https://compute.googleapis.com/compute/v1/projects/test-project/global/networks/default"
+        }
+      ],
+      "disks": [
+        {
+          "mode": "READ_WRITE",
+          "boot": true,
+          "deviceName": "booter",
+          "initializeParams": {
+            "sourceImage": "https://compute.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-10"
+          },
+          "autoDelete": true,
+          "type": "PERSISTENT"
+        }
+      ]
+    },
+    "response": {
+      "status": "RUNNING",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/operations/operation-1619206809737-5c0a8f6b65a76-ee4c1773-b89215cb",
+      "targetId": "6816838088127323253",
+      "startTime": "2021-04-23T12:40:10.699-07:00",
+      "id": "4483070932426857589",
+      "@type": "type.googleapis.com/operation",
+      "user": "test.user@cleardata.com",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/operations/4483070932426857589",
+      "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a",
+      "name": "operation-1619206809737-5c0a8f6b65a76-ee4c1773-b89215cb",
+      "operationType": "insert",
+      "insertTime": "2021-04-23T12:40:10.696-07:00",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-central1-a/instances/gcloud-devicename-mismatch",
+      "progress": "0"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-central1-a"
+      ]
+    }
+  },
+  "insertId": "-o4ntu5e1o6ji",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "project_id": "test-project",
+      "zone": "us-central1-a",
+      "instance_id": "6816838088127323253"
+    }
+  },
+  "timestamp": "2021-04-23T19:40:09.792987Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1619206809737-5c0a8f6b65a76-ee4c1773-b89215cb",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-23T19:40:11.435692357Z"
+}

--- a/tests/data/compute_instance_creation_logs_5.json
+++ b/tests/data/compute_instance_creation_logs_5.json
@@ -1,0 +1,118 @@
+{
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "service-974894326962@gcp-sa-notebooks.iam.gserviceaccount.com"
+    },
+    "requestMetadata": {},
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.instances.insert",
+    "resourceName": "projects/test-project/zones/us-west1-b/instances/demo-testing-good",
+    "request": {
+      "requestId": "bfe11378-6130-42d4-babb-82f697690ac8",
+      "machineType": "zones/us-west1-b/machineTypes/n1-standard-4",
+      "@type": "type.googleapis.com/compute.instances.insert",
+      "serviceAccounts": [
+        {
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email"
+          ],
+          "email": "compute-full@test-project.iam.gserviceaccount.com"
+        }
+      ],
+      "tags": {
+        "tags": [
+          "deeplearning-vm",
+          "notebook-instance"
+        ]
+      },
+      "labels": [
+        {
+          "key": "goog-caip-notebook",
+          "value": ""
+        }
+      ],
+      "scheduling": {
+        "onHostMaintenance": "MIGRATE"
+      },
+      "name": "demo-testing-good",
+      "disks": [
+        {
+          "type": "PERSISTENT",
+          "deviceName": "boot",
+          "autoDelete": true,
+          "boot": true,
+          "initializeParams": {
+            "diskType": "projects/test-project/zones/us-west1-b/diskTypes/pd-standard",
+            "sourceImage": "projects/deeplearning-platform-release/global/images/family/common-cpu-notebooks-debian-10",
+            "diskName": "demo-testing-good-boot",
+            "labels": [
+              {
+                "key": "goog-caip-notebook-volume",
+                "value": ""
+              }
+            ],
+            "diskSizeGb": "100"
+          }
+        },
+        {
+          "type": "PERSISTENT",
+          "autoDelete": true,
+          "initializeParams": {
+            "diskType": "projects/test-project/zones/us-west1-b/diskTypes/pd-standard",
+            "diskSizeGb": "100",
+            "labels": [
+              {
+                "key": "goog-caip-notebook-volume",
+                "value": ""
+              }
+            ],
+            "diskName": "demo-testing-good-data"
+          },
+          "deviceName": "data"
+        }
+      ]
+    },
+    "response": {
+      "insertTime": "2021-04-15T10:43:09.881-07:00",
+      "operationType": "insert",
+      "targetId": "4224659083998119362",
+      "targetLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/instances/demo-testing-good",
+      "name": "operation-1618508588353-5c0066579885a-833360e6-629e748b",
+      "selfLinkWithId": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/operations/4053444786883249602",
+      "startTime": "2021-04-15T10:43:09.883-07:00",
+      "clientOperationId": "bfe11378-6130-42d4-babb-82f697690ac8",
+      "id": "4053444786883249602",
+      "status": "RUNNING",
+      "@type": "type.googleapis.com/operation",
+      "selfLink": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b/operations/operation-1618508588353-5c0066579885a-833360e6-629e748b",
+      "progress": "0",
+      "zone": "https://www.googleapis.com/compute/v1/projects/test-project/zones/us-west1-b",
+      "user": "service-974894326962@gcp-sa-notebooks.iam.gserviceaccount.com"
+    },
+    "resourceLocation": {
+      "currentLocations": [
+        "us-west1-b"
+      ]
+    }
+  },
+  "insertId": "r78f6xe3o5bi",
+  "resource": {
+    "type": "gce_instance",
+    "labels": {
+      "zone": "us-west1-b",
+      "instance_id": "4224659083998119362",
+      "project_id": "test-project"
+    }
+  },
+  "timestamp": "2021-04-15T17:43:08.405047Z",
+  "severity": "NOTICE",
+  "logName": "projects/test-project/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "id": "operation-1618508588353-5c0066579885a-833360e6-629e748b",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "receiveTimestamp": "2021-04-15T17:43:10.665978926Z"
+}


### PR DESCRIPTION
This expands the supported formats for getting compute disk names from compute instance creation audit logs. I created instances with the console and via gcloud with various disks, disk names, and device names and included samples of those audit logs in the tests.

This will also reduce the number of times we evaluate (or attempt to evaluate non-existant) compute disks. Previously if an audit log contained no disk info we assumed the disk name matched the instance name. As a result, compute instance modifications also triggered disk evals. Now if there are no disks mentioned in the audit log, we don't attempt to evaluate any disks.